### PR TITLE
Make flow driver customizable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ parallel (
     }
   },
   'Tests': {
-    node('helix') {
+    node('elixir') {
       stage('Tests') {
         step([$class: 'WsCleanup'])
 

--- a/lib/helf/flow.ex
+++ b/lib/helf/flow.ex
@@ -1,7 +1,11 @@
 defmodule HELF.Flow do
 
-  # TODO: make this configurable
-  @driver Mix.env == :test && HELF.Flow.Driver.Sync || HELF.Flow.Driver.Async
+  case Application.get_env(:helf, :driver, :async) do
+    :sync ->
+      @driver HELF.Flow.Driver.Sync
+    :async ->
+      @driver HELF.Flow.Driver.Async
+  end
 
   def __driver__,
     do: @driver


### PR DESCRIPTION
`Mix.env` does not work properly when lib is being compiled; it always compiles as `:prod`.

See https://github.com/appsignal/appsignal-elixir/issues/91

---

Incidental (and very old):

- Jenkins-related commits